### PR TITLE
Keep the newlines on configuration options so that Neutron can read them

### DIFF
--- a/templates/default/neutron.conf.erb
+++ b/templates/default/neutron.conf.erb
@@ -101,18 +101,18 @@ dhcp_lease_duration = <%= node["openstack"]["network"]["dhcp_lease_duration"] %>
 # The messaging module to use, defaults to kombu.
 # rpc_backend = neutron.openstack.common.rpc.impl_kombu
 # Size of RPC thread pool
-rpc_thread_pool_size = <%= node['openstack']['network']['rpc_thread_pool_size'] -%>
+rpc_thread_pool_size = <%= node['openstack']['network']['rpc_thread_pool_size'] %>
 # Size of RPC connection pool
-rpc_conn_pool_size = <%= node['openstack']['network']['rpc_conn_pool_size'] -%>
+rpc_conn_pool_size = <%= node['openstack']['network']['rpc_conn_pool_size'] %>
 # Seconds to wait for a response from call or multicall
-rpc_response_timeout = <%= node['openstack']['network']['rpc_response_timeout'] -%>
+rpc_response_timeout = <%= node['openstack']['network']['rpc_response_timeout'] %>
 # Seconds to wait before a cast expires (TTL). Only supported by impl_zmq.
 # rpc_cast_timeout = 30
 # Modules of exceptions that are permitted to be recreated
 # upon receiving exception data from an rpc call.
 # allowed_rpc_exception_modules = neutron.openstack.common.exception, nova.exception
 # AMQP exchange to connect to if using RabbitMQ or QPID
-control_exchange = <%= node["openstack"]["network"]["control_exchange"] -%>
+control_exchange = <%= node["openstack"]["network"]["control_exchange"] %>
 
 # Configuration options if sending notifications via kombu rpc (these are
 # the defaults)
@@ -126,7 +126,7 @@ control_exchange = <%= node["openstack"]["network"]["control_exchange"] -%>
 # kombu_ssl_ca_certs =
 
 # allow_overlapping_ips = False
-allow_overlapping_ips = <%= node["openstack"]["network"]["allow_overlapping_ips"] -%>
+allow_overlapping_ips = <%= node["openstack"]["network"]["allow_overlapping_ips"] %>
 
 <% if @mq_service_type == "rabbitmq"  %>
 ##### RABBITMQ #####


### PR DESCRIPTION
If we remove the newlines neutron can't read the configuration options and you end up with it throwing exceptions and exiting:

```
# grep rpc_conn_pool_size *
neutron.conf:rpc_conn_pool_size = 30# Seconds to wait for a response from call or multicall
```

```
2014-04-19 08:31:29.052 10065 TRACE neutron.service Traceback (most recent call last):
2014-04-19 08:31:29.052 10065 TRACE neutron.service   File "/usr/lib/python2.7/dist-packages/neutron/service.py", line 105, in serve_wsgi
2014-04-19 08:31:29.052 10065 TRACE neutron.service     service = cls.create()
2014-04-19 08:31:29.052 10065 TRACE neutron.service   File "/usr/lib/python2.7/dist-packages/neutron/service.py", line 96, in create
2014-04-19 08:31:29.052 10065 TRACE neutron.service     cfg.CONF.log_opt_values(LOG, std_logging.DEBUG)
2014-04-19 08:31:29.052 10065 TRACE neutron.service   File "/usr/lib/python2.7/dist-packages/oslo/config/cfg.py", line 1941, in log_opt_values
2014-04-19 08:31:29.052 10065 TRACE neutron.service     _sanitize(opt, getattr(self, opt_name)))
2014-04-19 08:31:29.052 10065 TRACE neutron.service   File "/usr/lib/python2.7/dist-packages/oslo/config/cfg.py", line 1648, in __getattr__
2014-04-19 08:31:29.052 10065 TRACE neutron.service     raise NoSuchOptError(name)
2014-04-19 08:31:29.052 10065 TRACE neutron.service NoSuchOptError: no such option: rpc_response_timeout
```
